### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/fluent/migrate/__init__.py
+++ b/fluent/migrate/__init__.py
@@ -1,5 +1,3 @@
-# coding=utf8
-
 from .transforms import (                              # noqa: F401
     CONCAT, COPY, COPY_PATTERN, PLURALS, REPLACE, REPLACE_IN_TEXT
 )

--- a/fluent/migrate/_context.py
+++ b/fluent/migrate/_context.py
@@ -1,12 +1,8 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import os
 import codecs
 from functools import partial
 import logging
-from six.moves import zip_longest
+from itertools import zip_longest
 
 import fluent.syntax.ast as FTL
 from fluent.syntax.parser import FluentParser
@@ -21,7 +17,7 @@ from .errors import (
 )
 
 
-class InternalContext(object):
+class InternalContext:
     """Internal context for merging translation resources.
 
     For the public interface, see `context.MigrationContext`.
@@ -64,7 +60,7 @@ class InternalContext(object):
             contents = f.read()
         except UnicodeDecodeError as err:
             logger = logging.getLogger('migrate')
-            logger.warning('Unable to read file {}: {}'.format(path, err))
+            logger.warning(f'Unable to read file {path}: {err}')
             raise err
         finally:
             f.close()
@@ -82,7 +78,7 @@ class InternalContext(object):
             logger = logging.getLogger('migrate')
             for annot in annots:
                 msg = annot.message
-                logger.warning('Syntax error in {}: {}'.format(path, msg))
+                logger.warning(f'Syntax error in {path}: {msg}')
 
         return ast
 
@@ -105,12 +101,12 @@ class InternalContext(object):
         fullpath = os.path.join(self.reference_dir, path)
         try:
             return self.read_ftl_resource(fullpath)
-        except IOError:
-            error_message = 'Missing reference file: {}'.format(fullpath)
+        except OSError:
+            error_message = f'Missing reference file: {fullpath}'
             logging.getLogger('migrate').error(error_message)
             raise UnreadableReferenceError(error_message)
         except UnicodeDecodeError as err:
-            error_message = 'Error reading file {}: {}'.format(fullpath, err)
+            error_message = f'Error reading file {fullpath}: {err}'
             logging.getLogger('migrate').error(error_message)
             raise UnreadableReferenceError(error_message)
 
@@ -123,7 +119,7 @@ class InternalContext(object):
         fullpath = os.path.join(self.localization_dir, path)
         try:
             return self.read_ftl_resource(fullpath)
-        except IOError:
+        except OSError:
             logger = logging.getLogger('migrate')
             logger.info(
                 'Localization file {} does not exist and '
@@ -150,9 +146,9 @@ class InternalContext(object):
                 collection = self.read_legacy_resource(fullpath)
             else:
                 collection = self.read_ftl_resource(fullpath)
-        except IOError:
+        except OSError:
             logger = logging.getLogger('migrate')
-            logger.warning('Missing localization file: {}'.format(path))
+            logger.warning(f'Missing localization file: {path}')
         else:
             self.localization_resources[path] = collection
 

--- a/fluent/migrate/blame.py
+++ b/fluent/migrate/blame.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import argparse
 import json
 import os
@@ -13,7 +9,7 @@ import hglib
 from hglib.util import b, cmdbuilder
 
 
-class Blame(object):
+class Blame:
     def __init__(self, client):
         self.client = client
         self.users = []
@@ -53,7 +49,7 @@ class Blame(object):
                 key_vals = []
             if isinstance(e, FluentEntity):
                 key_vals += [
-                    ('{}.{}'.format(e.key, attr.key), attr.val_span)
+                    (f'{e.key}.{attr.key}', attr.val_span)
                     for attr in e.attributes
                 ]
             for key, (val_start, val_end) in key_vals:

--- a/fluent/migrate/changesets.py
+++ b/fluent/migrate/changesets.py
@@ -1,6 +1,3 @@
-# coding=utf8
-from __future__ import absolute_import
-
 import time
 
 

--- a/fluent/migrate/context.py
+++ b/fluent/migrate/context.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import logging
 
 import fluent.syntax.ast as FTL
@@ -54,7 +50,7 @@ class MigrationContext(InternalContext):
     def __init__(
         self, locale, reference_dir, localization_dir, enforce_translated=False
     ):
-        super(MigrationContext, self).__init__(
+        super().__init__(
             locale, reference_dir, localization_dir,
             enforce_translated=enforce_translated
         )
@@ -131,7 +127,7 @@ class MigrationContext(InternalContext):
         # may fail but a single missing legacy resource doesn't mean that the
         # migration can't succeed.
         for dependencies in self.dependencies.values():
-            for path in set(path for path, _ in dependencies):
+            for path in {path for path, _ in dependencies}:
                 expected_paths.add(path)
                 self.maybe_add_localization(path)
 

--- a/fluent/migrate/helpers.py
+++ b/fluent/migrate/helpers.py
@@ -1,4 +1,3 @@
-# coding=utf8
 """Fluent AST helpers.
 
 The functions defined in this module offer a shorthand for defining common AST
@@ -8,8 +7,6 @@ They take a string argument and immediately return a corresponding AST node.
 (As opposed to Transforms which are AST nodes on their own and only return the
 migrated AST nodes when they are evaluated by a MigrationContext.) """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
 
 from fluent.syntax import FluentParser, ast as FTL
 from fluent.syntax.visitor import Transformer

--- a/fluent/migrate/merge.py
+++ b/fluent/migrate/merge.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import fluent.syntax.ast as FTL
 
 from .errors import SkipTransform

--- a/fluent/migrate/tool.py
+++ b/fluent/migrate/tool.py
@@ -6,7 +6,6 @@ import importlib
 import sys
 
 import hglib
-import six
 
 from fluent.migrate.context import MigrationContext
 from fluent.migrate.errors import MigrationError

--- a/fluent/migrate/tool.py
+++ b/fluent/migrate/tool.py
@@ -1,5 +1,3 @@
-# coding=utf8
-
 import os
 import logging
 import argparse
@@ -24,7 +22,7 @@ def dont_write_bytecode():
     sys.dont_write_bytecode = _dont_write_bytecode
 
 
-class Migrator(object):
+class Migrator:
     def __init__(self, locale, reference_dir, localization_dir, dry_run):
         self.locale = locale
         self.reference_dir = reference_dir
@@ -95,9 +93,9 @@ class Migrator(object):
 
     def serialize_changeset(self, snapshot):
         '''Write serialized FTL files to disk.'''
-        for path, content in six.iteritems(snapshot):
+        for path, content in snapshot.items():
             fullpath = os.path.join(self.localization_dir, path)
-            print('  Writing to {}'.format(fullpath))
+            print(f'  Writing to {fullpath}')
             if not self.dry_run:
                 fulldir = os.path.dirname(fullpath)
                 if not os.path.isdir(fulldir):
@@ -114,7 +112,7 @@ class Migrator(object):
             author=author
         )
 
-        print('  Committing changeset: {}'.format(message))
+        print(f'  Committing changeset: {message}')
         if self.dry_run:
             return
         try:
@@ -122,7 +120,7 @@ class Migrator(object):
                 message, user=author.encode('utf-8'), addremove=True
             )
         except hglib.error.CommandError as err:
-            print('    WARNING: hg commit failed ({})'.format(err))
+            print(f'    WARNING: hg commit failed ({err})')
 
 
 def main(locale, reference_dir, localization_dir, migrations, dry_run):

--- a/fluent/migrate/transforms.py
+++ b/fluent/migrate/transforms.py
@@ -1,4 +1,3 @@
-# coding=utf8
 """Migration Transforms.
 
 Transforms are AST nodes which describe how legacy translations should be
@@ -62,8 +61,6 @@ TextElement by PLURALS and then run through the REPLACE_IN_TEXT transform.
     )
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import re
 
 from fluent.syntax import ast as FTL
@@ -76,8 +73,7 @@ def chain_elements(elements):
     for element in elements:
         if isinstance(element, FTL.Pattern):
             # PY3 yield from element.elements
-            for child in element.elements:
-                yield child
+            yield from element.elements
         elif isinstance(element, FTL.PatternElement):
             yield element
         elif isinstance(element, FTL.Expression):
@@ -212,7 +208,7 @@ class FluentSource(Source):
                 'Cannot migrate from Term Attributes, as they are'
                 'locale-dependent ({})'.format(path)
             )
-        super(FluentSource, self).__init__(path, key)
+        super().__init__(path, key)
 
     def __call__(self, ctx):
         pattern = ctx.get_fluent_source_pattern(self.path, self.key)
@@ -236,7 +232,7 @@ class TransformPattern(FluentSource, Transformer):
     actual modifications.
     """
     def __call__(self, ctx):
-        pattern = super(TransformPattern, self).__call__(ctx)
+        pattern = super().__call__(ctx)
         return self.visit(pattern)
 
     def visit_Pattern(self, node):
@@ -284,7 +280,7 @@ class LegacySource(Source):
                 'Please use COPY_PATTERN to migrate from Fluent files '
                 '({})'.format(path))
 
-        super(LegacySource, self).__init__(path, key)
+        super().__init__(path, key)
         self.trim = trim
 
     def get_text(self, ctx):
@@ -311,7 +307,7 @@ class COPY(LegacySource):
     """Create a Pattern with the translation value from the given source."""
 
     def __call__(self, ctx):
-        element = super(COPY, self).__call__(ctx)
+        element = super().__call__(ctx)
         return Transform.pattern_of(element)
 
 
@@ -429,12 +425,12 @@ class REPLACE(LegacySource):
         elif path.endswith('.properties'):
             normalize_printf = True
 
-        super(REPLACE, self).__init__(path, key, **kwargs)
+        super().__init__(path, key, **kwargs)
         self.replacements = replacements
         self.normalize_printf = normalize_printf
 
     def __call__(self, ctx):
-        element = super(REPLACE, self).__call__(ctx)
+        element = super().__call__(ctx)
         return REPLACE_IN_TEXT(
             element, self.replacements,
             normalize_printf=self.normalize_printf
@@ -455,12 +451,12 @@ class PLURALS(LegacySource):
 
     def __init__(self, path, key, selector, foreach=Transform.pattern_of,
                  **kwargs):
-        super(PLURALS, self).__init__(path, key, **kwargs)
+        super().__init__(path, key, **kwargs)
         self.selector = selector
         self.foreach = foreach
 
     def __call__(self, ctx):
-        element = super(PLURALS, self).__call__(ctx)
+        element = super().__call__(ctx)
         selector = ctx.evaluate(self.selector)
         keys = ctx.plural_categories
         forms = [

--- a/fluent/migrate/util.py
+++ b/fluent/migrate/util.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import textwrap
 
 import fluent.syntax.ast as FTL

--- a/fluent/migrate/validator.py
+++ b/fluent/migrate/validator.py
@@ -1,10 +1,7 @@
-# coding=utf8
-from __future__ import absolute_import
-
 import argparse
 import ast
 import six
-from six.moves import zip_longest
+from itertools import zip_longest
 
 from fluent.migrate import transforms
 from fluent.migrate.errors import MigrationError
@@ -36,7 +33,7 @@ def process_assign(node, context):
             context[target.id] = val
 
 
-class Validator(object):
+class Validator:
     """Validate a migration recipe
 
     Extract information from the migration recipe about which files to
@@ -80,7 +77,7 @@ class Validator(object):
                     asname = alias.asname or alias.name
                     dotted = alias.name
                     if module:
-                        dotted = '{}.{}'.format(module, dotted)
+                        dotted = f'{module}.{dotted}'
                     global_assigns[asname] = dotted
         if not migrate_func:
             raise MigrateNotFoundException(
@@ -123,12 +120,12 @@ def full_name(node, global_assigns):
     return '.'.join(reversed(leafs))
 
 
-PATH_TYPES = six.string_types + (ast.Call,)
+PATH_TYPES = (str,) + (ast.Call,)
 
 
 class MigrateAnalyzer(ast.NodeVisitor):
     def __init__(self, ctx_var, global_assigns):
-        super(MigrateAnalyzer, self).__init__()
+        super().__init__()
         self.ctx_var = ctx_var
         self.global_assigns = global_assigns
         self.depth = 0
@@ -137,7 +134,7 @@ class MigrateAnalyzer(ast.NodeVisitor):
 
     def generic_visit(self, node):
         self.depth += 1
-        super(MigrateAnalyzer, self).generic_visit(node)
+        super().generic_visit(node)
         self.depth -= 1
 
     def visit_Assign(self, node):
@@ -202,7 +199,7 @@ class MigrateAnalyzer(ast.NodeVisitor):
             in_reference = self.global_assigns.get(in_reference.id)
         if isinstance(in_reference, ast.Str):
             in_reference = in_reference.s
-        if not isinstance(in_reference, six.string_types):
+        if not isinstance(in_reference, str):
             self.issues.append({
                 'msg': ref_msg,
                 'line': node.args[1].lineno,
@@ -222,7 +219,7 @@ class MigrateAnalyzer(ast.NodeVisitor):
         transform = getattr(transforms, called)
         if not issubclass(transform, transforms.Source):
             return
-        bad_args = '{} takes path and key as first two params'.format(called)
+        bad_args = f'{called} takes path and key as first two params'
         if not self.check_arguments(
             node, ((ast.Str, ast.Name), (ast.Str, ast.Name),),
             allow_more=True, check_kwargs=False
@@ -314,7 +311,7 @@ class MigrateAnalyzer(ast.NodeVisitor):
 
 class TransformsInspector(Visitor):
     def __init__(self):
-        super(TransformsInspector, self).__init__()
+        super().__init__()
         self.issues = []
 
     def generic_visit(self, node):
@@ -324,9 +321,9 @@ class TransformsInspector(Visitor):
             # https://bugzilla.mozilla.org/show_bug.cgi?id=1568199
             if src != mozpath.normpath(src):
                 self.issues.append(
-                    'Source "{}" needs to be a normalized path'.format(src)
+                    f'Source "{src}" needs to be a normalized path'
                 )
-        super(TransformsInspector, self).generic_visit(node)
+        super().generic_visit(node)
 
 
 def cli():

--- a/fluent/migrate/validator.py
+++ b/fluent/migrate/validator.py
@@ -1,6 +1,5 @@
 import argparse
 import ast
-import six
 from itertools import zip_longest
 
 from fluent.migrate import transforms

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     ],
     packages=['fluent', 'fluent.migrate'],
     install_requires=[
-        'compare-locales >=8.1, <9.0',
-        'fluent.syntax >=0.18.0, <0.19',
+        'compare-locales >=9.0.1, <10.0',
+        'fluent.syntax >=0.19.0, <0.20',
     ],
     extras_require={
         'hg': ['python-hglib',],

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     packages=['fluent', 'fluent.migrate'],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     install_requires=[
         'compare-locales >=8.1, <9.0',
         'fluent.syntax >=0.18.0, <0.19',
-        'six',
     ],
     extras_require={
         'hg': ['python-hglib',],

--- a/tests/migrate/test_blame.py
+++ b/tests/migrate/test_blame.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from datetime import datetime
 import os
@@ -14,7 +10,7 @@ from fluent.migrate.blame import Blame
 
 class MockedBlame(Blame):
     def __init__(self, unicode_content):
-        super(MockedBlame, self).__init__(None)
+        super().__init__(None)
         self.content = unicode_content
 
     def readFile(self, parser, path):
@@ -110,7 +106,7 @@ class TestIntegration(unittest.TestCase):
         client.open()
         client.commit(
             message='Initial commit',
-            user='Hüsker Dü'.encode('utf-8'),
+            user='Hüsker Dü'.encode(),
             date=datetime.fromtimestamp(self.timestamps[0]),
             addremove=True,
         )
@@ -118,7 +114,7 @@ class TestIntegration(unittest.TestCase):
             f.write('two = second line\n')
         client.commit(
             message='Second commit',
-            user='😂'.encode('utf-8'),
+            user='😂'.encode(),
             date=datetime.fromtimestamp(self.timestamps[1]),
             addremove=True,
         )

--- a/tests/migrate/test_changesets.py
+++ b/tests/migrate/test_changesets.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 
 from fluent.migrate.changesets import convert_blame_to_changesets

--- a/tests/migrate/test_concat.py
+++ b/tests/migrate/test_concat.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from compare_locales.parser import PropertiesParser, DTDParser
 

--- a/tests/migrate/test_concat_integration.py
+++ b/tests/migrate/test_concat_integration.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from compare_locales.parser import PropertiesParser, DTDParser
 

--- a/tests/migrate/test_context.py
+++ b/tests/migrate/test_context.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import six
 import unittest
 
 import fluent.syntax.ast as FTL

--- a/tests/migrate/test_context.py
+++ b/tests/migrate/test_context.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import os
 import logging
 import six
@@ -40,7 +36,7 @@ class TestMigrationContext_AddTransforms(unittest.TestCase):
             ),
         ])
         self.assertSetEqual(
-            self.ctx.dependencies[(u'aboutDownloads.ftl', u'about')],
+            self.ctx.dependencies[('aboutDownloads.ftl', 'about')],
             set()
         )
         self.assertTrue(
@@ -424,7 +420,7 @@ class TestMissingLocalizationFiles(unittest.TestCase):
 
     def test_all_files_missing(self):
         pattern = ('No localization files were found')
-        with six.assertRaisesRegex(self, EmptyLocalizationError, pattern):
+        with self.assertRaisesRegex(EmptyLocalizationError, pattern):
             self.ctx.add_transforms('existing.ftl', 'existing.ftl', [
                 FTL.Message(
                     id=FTL.Identifier('foo'),

--- a/tests/migrate/test_context_real_examples.py
+++ b/tests/migrate/test_context_real_examples.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import os
 import unittest
 

--- a/tests/migrate/test_copy.py
+++ b/tests/migrate/test_copy.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 
 from fluent.migrate.transforms import COPY

--- a/tests/migrate/test_copy_integration.py
+++ b/tests/migrate/test_copy_integration.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from datetime import datetime
 import os
@@ -13,7 +9,7 @@ from fluent.migrate.helpers import transforms_from
 from fluent.migrate import tool
 
 
-class MockMigrationModule(object):
+class MockMigrationModule:
     __name__ = 'tests.migrate.some'
     @staticmethod
     def migrate(ctx):
@@ -50,7 +46,7 @@ target = should be migrated.
         client.open()
         client.commit(
             message='Initial commit',
-            user='Hüsker Dü'.encode('utf-8'),
+            user='Hüsker Dü'.encode(),
             date=datetime.fromtimestamp(self.timestamps[0]),
             addremove=True,
         )
@@ -60,7 +56,7 @@ target = should be migrated.
             f.write('<!ENTITY one.with "attribute">\n')
         client.commit(
             message='Second commit',
-            user='😂'.encode('utf-8'),
+            user='😂'.encode(),
             date=datetime.fromtimestamp(self.timestamps[1]),
             addremove=True,
         )
@@ -80,8 +76,8 @@ target = should be migrated.
         tip = self.client.tip()
         # There is only one commit
         self.assertEqual(tip.rev, b'2')
-        self.assertEqual(tip.author, '😂'.encode('utf-8'))
-        with open(os.path.join(self.root, 'pl', 'd1', 'f1.ftl'), 'r') as f:
+        self.assertEqual(tip.author, '😂'.encode())
+        with open(os.path.join(self.root, 'pl', 'd1', 'f1.ftl')) as f:
             content = f.read()
         self.assertEqual(
             content,

--- a/tests/migrate/test_copy_pattern_integration.py
+++ b/tests/migrate/test_copy_pattern_integration.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from datetime import datetime
 import os
@@ -13,7 +9,7 @@ from fluent.migrate.helpers import transforms_from
 from fluent.migrate import tool
 
 
-class MockMigrationModule(object):
+class MockMigrationModule:
     __name__ = 'tests.migrate.some'
     @staticmethod
     def migrate(ctx):
@@ -48,7 +44,7 @@ target = should be migrated.
         client.open()
         client.commit(
             message='Initial commit',
-            user='Hüsker Dü'.encode('utf-8'),
+            user='Hüsker Dü'.encode(),
             date=datetime.fromtimestamp(self.timestamps[0]),
             addremove=True,
         )
@@ -56,7 +52,7 @@ target = should be migrated.
             f.write('    .with = attribute\n')
         client.commit(
             message='Second commit',
-            user='😂'.encode('utf-8'),
+            user='😂'.encode(),
             date=datetime.fromtimestamp(self.timestamps[1]),
             addremove=True,
         )
@@ -76,8 +72,8 @@ target = should be migrated.
         tip = self.client.tip()
         # There is only one commit
         self.assertEqual(tip.rev, b'2')
-        self.assertEqual(tip.author, '😂'.encode('utf-8'))
-        with open(os.path.join(self.root, 'pl', 'd1', 'f1.ftl'), 'r') as f:
+        self.assertEqual(tip.author, '😂'.encode())
+        with open(os.path.join(self.root, 'pl', 'd1', 'f1.ftl')) as f:
             content = f.read()
         self.assertEqual(
             content,

--- a/tests/migrate/test_helpers.py
+++ b/tests/migrate/test_helpers.py
@@ -1,10 +1,6 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 import six
-from six.moves import zip_longest
+from itertools import zip_longest
 
 import fluent.syntax.ast as FTL
 from fluent.migrate.helpers import transforms_from, MESSAGE_REFERENCE
@@ -269,21 +265,21 @@ new-key =
 
     def test_implicit_transform(self):
         pattern = "runs implicitly"
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             transforms_from("""
 new-key = { CONCAT("a", "b") }
 """)
 
     def test_forbidden_transform(self):
         pattern = "requires additional logic"
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             transforms_from("""
 new-key = { REPLACE() }
 """)
 
     def test_broken_transform(self):
         pattern = "contains parse error"
-        with six.assertRaisesRegex(self, InvalidTransformError, pattern):
+        with self.assertRaisesRegex(InvalidTransformError, pattern):
             transforms_from("""
 new-key = { COPY('path', 'key') }
 """)
@@ -304,14 +300,14 @@ new-key = { COPY(from_path, "key") }
 
     def test_unknown_substitution_name(self):
         pattern = "Unknown substitution in COPY: unknown_path"
-        with six.assertRaisesRegex(self, InvalidTransformError, pattern):
+        with self.assertRaisesRegex(InvalidTransformError, pattern):
             transforms_from("""
 new-key = { COPY(unknown_path, "key") }
 """)
 
     def test_invalid_argument_type(self):
         pattern = "Invalid argument passed to COPY: VariableReference"
-        with six.assertRaisesRegex(self, InvalidTransformError, pattern):
+        with self.assertRaisesRegex(InvalidTransformError, pattern):
             transforms_from("""
 new-key = { COPY($invalid_type, "key") }
 """)

--- a/tests/migrate/test_helpers.py
+++ b/tests/migrate/test_helpers.py
@@ -1,5 +1,4 @@
 import unittest
-import six
 from itertools import zip_longest
 
 import fluent.syntax.ast as FTL

--- a/tests/migrate/test_merge.py
+++ b/tests/migrate/test_merge.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from compare_locales.parser import PropertiesParser, DTDParser
 

--- a/tests/migrate/test_plural.py
+++ b/tests/migrate/test_plural.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from compare_locales.parser import PropertiesParser
 

--- a/tests/migrate/test_replace.py
+++ b/tests/migrate/test_replace.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 from compare_locales.parser import PropertiesParser
 

--- a/tests/migrate/test_source.py
+++ b/tests/migrate/test_source.py
@@ -1,5 +1,4 @@
 import unittest
-import six
 from compare_locales.parser import PropertiesParser, DTDParser
 
 import fluent.syntax.ast as FTL

--- a/tests/migrate/test_source.py
+++ b/tests/migrate/test_source.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 import six
 from compare_locales.parser import PropertiesParser, DTDParser
@@ -19,17 +15,17 @@ from fluent.migrate.helpers import VARIABLE_REFERENCE
 class TestNotSupportedError(unittest.TestCase):
     def test_source(self):
         pattern = ('Please use COPY_PATTERN to migrate from Fluent files')
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             LegacySource('test.ftl', 'foo')
 
     def test_copy(self):
         pattern = ('Please use COPY_PATTERN to migrate from Fluent files')
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             COPY('test.ftl', 'foo')
 
     def test_plurals(self):
         pattern = ('Please use COPY_PATTERN to migrate from Fluent files')
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             PLURALS(
                 'test.ftl',
                 'deleteAll',
@@ -38,7 +34,7 @@ class TestNotSupportedError(unittest.TestCase):
 
     def test_replace(self):
         pattern = ('Please use COPY_PATTERN to migrate from Fluent files')
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             REPLACE(
                 'test.ftl',
                 'hello',
@@ -49,13 +45,13 @@ class TestNotSupportedError(unittest.TestCase):
 
     def test_copy_pattern(self):
         pattern = ('Please use COPY to migrate from legacy files')
-        with six.assertRaisesRegex(self, NotSupportedError, pattern):
+        with self.assertRaisesRegex(NotSupportedError, pattern):
             COPY_PATTERN('test.properties', 'foo')
         self.assertIsNotNone(COPY_PATTERN('test.ftl', 'foo'))
         self.assertIsNotNone(COPY_PATTERN('test.ftl', 'foo.bar'))
         self.assertIsNotNone(COPY_PATTERN('test.ftl', '-foo'))
         term_attr_pattern = ('Cannot migrate from Term Attributes')
-        with six.assertRaisesRegex(self, NotSupportedError, term_attr_pattern):
+        with self.assertRaisesRegex(NotSupportedError, term_attr_pattern):
             COPY_PATTERN('test.ftl', '-foo.bar')
 
 

--- a/tests/migrate/test_tool.py
+++ b/tests/migrate/test_tool.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 import os
 import shutil

--- a/tests/migrate/test_transform_patttern.py
+++ b/tests/migrate/test_transform_patttern.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 
 from fluent.migrate.context import MigrationContext
@@ -53,7 +49,7 @@ selected = {$foo ->
 
 class VariantPicker(TransformPattern):
     def __init__(self, path, key, variant, exclude=False):
-        super(VariantPicker, self).__init__(path, key)
+        super().__init__(path, key)
         self.variant = variant
         self.exclude = exclude
 

--- a/tests/migrate/test_transforms.py
+++ b/tests/migrate/test_transforms.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 
 from fluent.migrate.transforms import (

--- a/tests/migrate/test_util.py
+++ b/tests/migrate/test_util.py
@@ -1,7 +1,3 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import unittest
 
 import fluent.syntax.ast as FTL

--- a/tests/migrate/test_validator.py
+++ b/tests/migrate/test_validator.py
@@ -1,11 +1,7 @@
-# coding=utf8
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import ast
 import unittest
 
-import mock
+from unittest import mock
 
 from fluent.migrate import validator
 from fluent.migrate import COPY, COPY_PATTERN

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py37, py38, py39, py310
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
- Apply `pyupgrade --py37-plus`
- Drop dependency on `six`
- Add support for Python 3.8, 3.9 & 3.10
- Update to compare-locales 9.0.1 & fluent.syntax 0.19.0