### PR TITLE
Cleanup & preparation for further changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/fluent/migrate/changesets.py
+++ b/fluent/migrate/changesets.py
@@ -1,12 +1,25 @@
+from __future__ import annotations
+from typing import Set, Tuple, TypedDict
+
 import time
 
+from .blame import BlameResult
 
-def by_first_commit(item):
+Changes = Set[Tuple[str, str]]
+
+
+class Changeset(TypedDict):
+    author: str
+    first_commit: float
+    changes: Changes
+
+
+def by_first_commit(item: Changeset):
     """Order two changesets by their first commit date."""
     return item["first_commit"]
 
 
-def convert_blame_to_changesets(blame_json):
+def convert_blame_to_changesets(blame_json: BlameResult) -> list[Changeset]:
     """Convert a blame dict into a list of changesets.
 
     The blame information in `blame_json` should be a dict of the following
@@ -38,7 +51,7 @@ def convert_blame_to_changesets(blame_json):
 
     """
     now = time.time()
-    changesets = [
+    changesets: list[Changeset] = [
         {"author": author, "first_commit": now, "changes": set()}
         for author in blame_json["authors"]
     ]

--- a/fluent/migrate/context.py
+++ b/fluent/migrate/context.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+from typing import List, Set, Tuple, cast
+
 import logging
 
 import fluent.syntax.ast as FTL
@@ -48,12 +51,14 @@ class MigrationContext(InternalContext):
     """
 
     def __init__(
-        self, locale, reference_dir, localization_dir, enforce_translated=False
+        self,
+        locale: str,
+        reference_dir: str,
+        localization_dir: str,
+        enforce_translated=False,
     ):
         super().__init__(
             locale,
-            reference_dir,
-            localization_dir,
             enforce_translated=enforce_translated,
         )
         self.locale = locale
@@ -61,12 +66,16 @@ class MigrationContext(InternalContext):
         self.reference_dir = reference_dir
         self.localization_dir = localization_dir
 
-        # A dict whose keys are `(path, key)` tuples corresponding to target
-        # FTL translations, and values are sets of `(path, key)` tuples
-        # corresponding to localized entities which will be migrated.
         self.dependencies = {}
+        """
+        A dict whose keys are `(path, key)` tuples corresponding to target
+        FTL translations, and values are sets of `(path, key)` tuples
+        corresponding to localized entities which will be migrated.
+        """
 
-    def add_transforms(self, target, reference, transforms):
+    def add_transforms(
+        self, target: str, reference: str, transforms: List[FTL.Message | FTL.Term]
+    ):
         """Define transforms for target using reference as template.
 
         `target` is a path of the destination FTL file relative to the
@@ -102,10 +111,10 @@ class MigrationContext(InternalContext):
         self.reference_resources[target] = reference_ast
 
         for node in transforms:
-            ident = node.id.name
+            ident = cast(str, node.id.name)
             # Scan `node` for `Source` nodes and collect the information they
             # store into a set of dependencies.
-            dependencies = fold(get_sources, node, set())
+            dependencies = cast(Set[Tuple[str, Source]], fold(get_sources, node, set()))
             # Set these sources as dependencies for the current transform.
             self.dependencies[(target, ident)] = dependencies
 

--- a/fluent/migrate/helpers.py
+++ b/fluent/migrate/helpers.py
@@ -7,6 +7,9 @@ They take a string argument and immediately return a corresponding AST node.
 (As opposed to Transforms which are AST nodes on their own and only return the
 migrated AST nodes when they are evaluated by a MigrationContext.) """
 
+from __future__ import annotations
+from typing import List
+
 from fluent.syntax import FluentParser, ast as FTL
 from fluent.syntax.visitor import Transformer
 from .transforms import Transform, CONCAT, COPY, COPY_PATTERN
@@ -123,7 +126,7 @@ class IntoTranforms(Transformer):
             )
 
 
-def transforms_from(ftl, **substitutions):
+def transforms_from(ftl, **substitutions) -> List[FTL.Message | FTL.Term]:
     """Parse FTL code into a list of Message nodes with Transforms.
 
     The FTL may use a fabricated COPY function inside of placeables which

--- a/fluent/migrate/tool.py
+++ b/fluent/migrate/tool.py
@@ -1,15 +1,17 @@
-import os
-import logging
+from __future__ import annotations
+
 import argparse
 from contextlib import contextmanager
 import importlib
+import logging
+import os
 import sys
 
 import hglib
 
 from fluent.migrate.context import MigrationContext
 from fluent.migrate.errors import MigrationError
-from fluent.migrate.changesets import convert_blame_to_changesets
+from fluent.migrate.changesets import Changes, convert_blame_to_changesets
 from fluent.migrate.blame import Blame
 
 
@@ -22,7 +24,9 @@ def dont_write_bytecode():
 
 
 class Migrator:
-    def __init__(self, locale, reference_dir, localization_dir, dry_run):
+    def __init__(
+        self, locale: str, reference_dir: str, localization_dir: str, dry_run: bool
+    ):
         self.locale = locale
         self.reference_dir = reference_dir
         self.localization_dir = localization_dir
@@ -59,7 +63,7 @@ class Migrator:
 
         # Keep track of how many changesets we're committing.
         index = 0
-        description_template = migration.migrate.__doc__
+        description_template: str = migration.migrate.__doc__
 
         # Annotate localization files used as sources by this migration
         # to preserve attribution of translations.
@@ -78,7 +82,12 @@ class Migrator:
             index += 1
             self.commit_changeset(description_template, changeset["author"], index)
 
-    def snapshot(self, ctx, changes_in_changeset, known_legacy_translations):
+    def snapshot(
+        self,
+        ctx: MigrationContext,
+        changes_in_changeset: Changes,
+        known_legacy_translations: Changes,
+    ):
         """Run the migration for the changeset, with the set of
         this and all prior legacy translations.
         """
@@ -98,7 +107,7 @@ class Migrator:
                     f.write(content.encode("utf8"))
                     f.close()
 
-    def commit_changeset(self, description_template, author, index):
+    def commit_changeset(self, description_template: str, author, index):
         message = description_template.format(index=index, author=author)
 
         print(f"  Committing changeset: {message}")

--- a/tests/migrate/test_validator.py
+++ b/tests/migrate/test_validator.py
@@ -464,33 +464,35 @@ class TestMigrateAnalyzer_check_arguments(unittest.TestCase):
     def test_types(self):
         v = validator.MigrateAnalyzer("foo", {})
         call = ast.parse('foo("s")').body[0].value
-        self.assertTrue(v.check_arguments(call, (ast.Str,)))
-        self.assertTrue(v.check_arguments(call, ((ast.Str, ast.Name),)))
+        self.assertTrue(v.check_arguments(call, (ast.Constant,)))
+        self.assertTrue(v.check_arguments(call, ((ast.Constant, ast.Name),)))
         self.assertFalse(v.check_arguments(call, (ast.Name,)))
 
     def test_argument_count(self):
         v = validator.MigrateAnalyzer("foo", {})
         call = ast.parse('foo("s")').body[0].value
-        self.assertFalse(v.check_arguments(call, (ast.Str, ast.Str)))
-        self.assertFalse(v.check_arguments(call, (ast.Str, ast.Str), allow_more=True))
+        self.assertFalse(v.check_arguments(call, (ast.Constant, ast.Constant)))
+        self.assertFalse(
+            v.check_arguments(call, (ast.Constant, ast.Constant), allow_more=True)
+        )
         self.assertFalse(v.check_arguments(call, tuple()))
         self.assertTrue(v.check_arguments(call, tuple(), allow_more=True))
 
     def test_kwargs(self):
         v = validator.MigrateAnalyzer("foo", {})
         call = ast.parse('foo("s", some="stuff")').body[0].value
-        self.assertFalse(v.check_arguments(call, (ast.Str,)))
-        self.assertTrue(v.check_arguments(call, (ast.Str,), check_kwargs=False))
+        self.assertFalse(v.check_arguments(call, (ast.Constant,)))
+        self.assertTrue(v.check_arguments(call, (ast.Constant,), check_kwargs=False))
         call = ast.parse('foo("s", **kwargs)').body[0].value
-        self.assertFalse(v.check_arguments(call, (ast.Str,)))
-        self.assertTrue(v.check_arguments(call, (ast.Str,), check_kwargs=False))
+        self.assertFalse(v.check_arguments(call, (ast.Constant,)))
+        self.assertTrue(v.check_arguments(call, (ast.Constant,), check_kwargs=False))
 
     def test_starargs(self):
         v = validator.MigrateAnalyzer("foo", {})
         call = ast.parse("foo(*args)").body[0].value
-        self.assertFalse(v.check_arguments(call, (ast.Str,)))
-        self.assertFalse(v.check_arguments(call, (ast.Str,), check_kwargs=False))
-        self.assertFalse(v.check_arguments(call, (ast.Str,), allow_more=True))
+        self.assertFalse(v.check_arguments(call, (ast.Constant,)))
+        self.assertFalse(v.check_arguments(call, (ast.Constant,), check_kwargs=False))
+        self.assertFalse(v.check_arguments(call, (ast.Constant,), allow_more=True))
 
 
 class TestTransformsInspector(unittest.TestCase):


### PR DESCRIPTION
These are preparatory steps for making the code easier to work with going forward, applying a consistent code style, adding type hints (incomplete, but a start), and updating deprecated code.

~The first commit is a result of running `black` on all `.py` files, so reviewing the other changes is probably easier done commit by commit.~