### PR TITLE
Add RepoClient as wrapper that auto-detects and supports both git & hg

### DIFF
--- a/fluent/migrate/repo_client.py
+++ b/fluent/migrate/repo_client.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from typing import Tuple
+
+import json
+from subprocess import run
+
+from os.path import isdir, join
+
+import hglib
+
+
+class RepoClient:
+    def __init__(self, root: str):
+        self.root = root
+        if isdir(join(root, ".hg")):
+            self.hgclient = hglib.open(root, "utf-8")
+        elif isdir(join(root, ".git")):
+            self.hgclient = None
+            stdout = self._git("rev-parse", "--is-inside-work-tree")
+            if stdout != "true\n":
+                raise Exception("git rev-parse failed")
+        else:
+            raise Exception(f"Unsupported repository: {root}")
+
+    def close(self):
+        if self.hgclient:
+            self.hgclient.close()
+
+    def blame(self, file: str) -> list[Tuple[str, int]]:
+        "Return a list of (author, time) tuples for each line in `file`."
+        if self.hgclient:
+            args = hglib.util.cmdbuilder(
+                b"annotate",
+                file.encode("latin-1"),
+                template="json",
+                date=True,
+                user=True,
+                cwd=self.root,
+            )
+            blame_json = self.hgclient.rawcommand(args)
+            return [
+                (line["user"], int(line["date"][0]))
+                for line in json.loads(blame_json)[0]["lines"]
+            ]
+        else:
+            lines: list[Tuple[str, int]] = []
+            user = ""
+            time = 0
+            stdout = self._git("blame", "--porcelain", file)
+            for line in stdout.splitlines():
+                if line.startswith("author "):
+                    user = line[7:]
+                elif line.startswith("author-mail "):
+                    user += line[11:]  # includes leading space
+                elif line.startswith("author-time "):
+                    time = int(line[12:])
+                elif line.startswith("\t"):
+                    lines.append((user, time))
+            return lines
+
+    def commit(self, message: str, author: str):
+        "Add and commit all work tree files"
+        if self.hgclient:
+            self.hgclient.commit(message, user=author.encode("utf-8"), addremove=True)
+        else:
+            self._git("add", ".")
+            self._git("commit", f"--author={author}", f"--message={message}")
+
+    def _git(self, *args: str):
+        git = ["git"]
+        git.extend(args)
+        proc = run(git, capture_output=True, cwd=self.root, encoding="utf-8")
+        if proc.returncode != 0:
+            raise Exception(proc.stderr or f"git {args[0]} failed")
+        return proc.stdout

--- a/fluent/migrate/repo_client.py
+++ b/fluent/migrate/repo_client.py
@@ -104,6 +104,3 @@ class RepoClient:
                 .strip()
                 .splitlines()
             )
-
-    def _git(self, *args: str):
-        return git(self.root, *args)

--- a/fluent/migrate/repo_client.py
+++ b/fluent/migrate/repo_client.py
@@ -19,7 +19,7 @@ def git(root: str, *args: str) -> str:
     git.extend(args)
     proc = run(git, capture_output=True, cwd=root, encoding="utf-8")
     if proc.returncode != 0:
-        raise Exception(proc.stderr or f"git {args[0]} failed")
+        raise Exception(proc.stderr or f"git command failed: {args}")
     return proc.stdout
 
 

--- a/fluent/migrate/tool.py
+++ b/fluent/migrate/tool.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from types import ModuleType
+from typing import Iterable, cast
 
 import argparse
 from contextlib import contextmanager
@@ -7,12 +9,11 @@ import logging
 import os
 import sys
 
-import hglib
-
+from fluent.migrate.blame import Blame
+from fluent.migrate.changesets import Changes, convert_blame_to_changesets
 from fluent.migrate.context import MigrationContext
 from fluent.migrate.errors import MigrationError
-from fluent.migrate.changesets import Changes, convert_blame_to_changesets
-from fluent.migrate.blame import Blame
+from fluent.migrate.repo_client import RepoClient
 
 
 @contextmanager
@@ -36,7 +37,7 @@ class Migrator:
     @property
     def client(self):
         if self._client is None:
-            self._client = hglib.open(self.localization_dir, "utf-8")
+            self._client = RepoClient(self.localization_dir)
         return self._client
 
     def close(self):
@@ -44,7 +45,7 @@ class Migrator:
         if self._client is not None:
             self._client.close()
 
-    def run(self, migration):
+    def run(self, migration: ModuleType):
         print("\nRunning migration {} for {}".format(migration.__name__, self.locale))
 
         # For each migration create a new context.
@@ -63,7 +64,7 @@ class Migrator:
 
         # Keep track of how many changesets we're committing.
         index = 0
-        description_template: str = migration.migrate.__doc__
+        description_template = cast(str, migration.migrate.__doc__)
 
         # Annotate localization files used as sources by this migration
         # to preserve attribution of translations.
@@ -107,19 +108,25 @@ class Migrator:
                     f.write(content.encode("utf8"))
                     f.close()
 
-    def commit_changeset(self, description_template: str, author, index):
+    def commit_changeset(self, description_template: str, author: str, index: int):
         message = description_template.format(index=index, author=author)
 
         print(f"  Committing changeset: {message}")
         if self.dry_run:
             return
         try:
-            self.client.commit(message, user=author.encode("utf-8"), addremove=True)
-        except hglib.error.CommandError as err:
-            print(f"    WARNING: hg commit failed ({err})")
+            self.client.commit(message, author)
+        except Exception as err:
+            print(f"    WARNING: commit failed ({err})")
 
 
-def main(locale, reference_dir, localization_dir, migrations, dry_run):
+def main(
+    locale,
+    reference_dir: str,
+    localization_dir: str,
+    migrations: Iterable[ModuleType],
+    dry_run: bool,
+):
     """Run migrations and commit files with the result."""
     migrator = Migrator(locale, reference_dir, localization_dir, dry_run)
 

--- a/tests/migrate/test_blame.py
+++ b/tests/migrate/test_blame.py
@@ -131,6 +131,8 @@ class TestGitIntegration(unittest.TestCase):
         if proc.returncode != 0:
             raise Exception(proc.stderr or "git init failed")
         client = RepoClient(self.root)
+        client._git("config", "user.name", "Anon")
+        client._git("config", "user.email", "anon@example.com")
 
         makedirs(join(self.root, "d1"))
         with open(join(self.root, "d1", "f1.ftl"), "w") as f:

--- a/tests/migrate/test_blame.py
+++ b/tests/migrate/test_blame.py
@@ -1,11 +1,14 @@
 import unittest
 from datetime import datetime
-import os
+from os import makedirs
+from os.path import join
 import shutil
+from subprocess import run
 import tempfile
 import hglib
 
 from fluent.migrate.blame import Blame
+from fluent.migrate.repo_client import RepoClient
 
 
 class MockedBlame(Blame):
@@ -26,22 +29,11 @@ joe = second
 """
         )
         blame.handleFile(
-            {
-                "abspath": "file.properties",
-                "path": "file.properties",
-                "lines": [
-                    {
-                        "date": [10000.0, 0],
-                        "user": "Jane Doe <jane@example.tld>",
-                        "line": "jane = first\n",
-                    },
-                    {
-                        "date": [11000.0, 0],
-                        "user": "Joe Doe <joe@example.tld>",
-                        "line": "joe = second\n",
-                    },
-                ],
-            }
+            "file.properties",
+            [
+                ("Jane Doe <jane@example.tld>", 10000),
+                ("Joe Doe <joe@example.tld>", 11000),
+            ],
         )
         self.assertEqual(
             blame.users,
@@ -52,7 +44,7 @@ joe = second
         )
         self.assertEqual(
             blame.blame,
-            {"file.properties": {"jane": [0, 10000.0], "joe": [1, 11000.0]}},
+            {"file.properties": {"jane": (0, 10000), "joe": (1, 11000)}},
         )
 
     def test_fluent(self):
@@ -63,22 +55,11 @@ jane = first
 """
         )
         blame.handleFile(
-            {
-                "abspath": "file.ftl",
-                "path": "file.ftl",
-                "lines": [
-                    {
-                        "date": [10000.0, 0],
-                        "user": "Jane Doe <jane@example.tld>",
-                        "line": "jane = first\n",
-                    },
-                    {
-                        "date": [11000.0, 0],
-                        "user": "Joe Doe <joe@example.tld>",
-                        "line": "    .joe = second\n",
-                    },
-                ],
-            }
+            "file.ftl",
+            [
+                ("Jane Doe <jane@example.tld>", 10000),
+                ("Joe Doe <joe@example.tld>", 11000),
+            ],
         )
         self.assertEqual(
             blame.users,
@@ -88,28 +69,28 @@ jane = first
             ],
         )
         self.assertEqual(
-            blame.blame, {"file.ftl": {"jane": [0, 10000.0], "jane.joe": [1, 11000.0]}}
+            blame.blame, {"file.ftl": {"jane": (0, 10000), "jane.joe": (1, 11000)}}
         )
 
 
-class TestIntegration(unittest.TestCase):
+class TestHgIntegration(unittest.TestCase):
     def setUp(self):
         self.root = tempfile.mkdtemp()
-        self.timestamps = [1272837600, 1335996000]
-        os.makedirs(os.path.join(self.root, "d1"))
-        with open(os.path.join(self.root, "d1", "f1.ftl"), "w") as f:
+        self.timestamps = (1272837600, 1335996000)
+        makedirs(join(self.root, "d1"))
+        with open(join(self.root, "d1", "f1.ftl"), "w") as f:
             f.write("one = first line\n")
-        self.client = client = hglib.init(self.root, encoding="utf-8")
-        client.open()
-        client.commit(
+        self.hgclient = hgclient = hglib.init(self.root, encoding="utf-8")
+        hgclient.open()
+        hgclient.commit(
             message="Initial commit",
             user="Hüsker Dü".encode(),
             date=datetime.fromtimestamp(self.timestamps[0]),
             addremove=True,
         )
-        with open(os.path.join(self.root, "d1", "f1.ftl"), "a") as f:
+        with open(join(self.root, "d1", "f1.ftl"), "a") as f:
             f.write("two = second line\n")
-        client.commit(
+        hgclient.commit(
             message="Second commit",
             user="😂".encode(),
             date=datetime.fromtimestamp(self.timestamps[1]),
@@ -117,20 +98,77 @@ class TestIntegration(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.client.close()
+        self.hgclient.close()
         shutil.rmtree(self.root)
 
     def test_attribution(self):
-        blame = Blame(self.client)
+        client = RepoClient(self.root)
+        blame = Blame(client)
         rv = blame.attribution(["d1/f1.ftl"])
+        client.close()
         self.assertEqual(
             rv,
             {
                 "authors": ["Hüsker Dü", "😂"],
                 "blame": {
                     "d1/f1.ftl": {
-                        "one": [0, self.timestamps[0]],
-                        "two": [1, self.timestamps[1]],
+                        "one": (0, self.timestamps[0]),
+                        "two": (1, self.timestamps[1]),
+                    }
+                },
+            },
+        )
+
+
+class TestGitIntegration(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.timestamps = (1272837600, 1335996000)
+
+        proc = run(
+            ["git", "init"], capture_output=True, cwd=self.root, encoding="utf-8"
+        )
+        if proc.returncode != 0:
+            raise Exception(proc.stderr or "git init failed")
+        client = RepoClient(self.root)
+
+        makedirs(join(self.root, "d1"))
+        with open(join(self.root, "d1", "f1.ftl"), "w") as f:
+            f.write("one = first line\n")
+        client._git("add", ".")
+        client._git(
+            "commit",
+            f"--date={datetime.fromtimestamp(self.timestamps[0])}",
+            "--author=Hüsker Dü <husker@example.com>",
+            "--message=Initial commit",
+        )
+
+        with open(join(self.root, "d1", "f1.ftl"), "a") as f:
+            f.write("two = second line\n")
+        client._git(
+            "commit",
+            "--all",
+            f"--date={datetime.fromtimestamp(self.timestamps[1])}",
+            "--author=😂 <foo@bar.baz>",
+            "--message=Second commit",
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+    def test_attribution(self):
+        client = RepoClient(self.root)
+        self.assertIsNone(client.hgclient)
+        blame = Blame(client)
+        rv = blame.attribution(["d1/f1.ftl"])
+        self.assertEqual(
+            rv,
+            {
+                "authors": ["Hüsker Dü <husker@example.com>", "😂 <foo@bar.baz>"],
+                "blame": {
+                    "d1/f1.ftl": {
+                        "one": (0, self.timestamps[0]),
+                        "two": (1, self.timestamps[1]),
                     }
                 },
             },

--- a/tests/migrate/test_tool.py
+++ b/tests/migrate/test_tool.py
@@ -1,8 +1,11 @@
 import unittest
 import os
+from os.path import join, relpath
 import shutil
+from subprocess import run
 import tempfile
 
+from fluent.migrate.repo_client import RepoClient
 from fluent.migrate.tool import Migrator
 import hglib
 
@@ -12,8 +15,8 @@ class TestSerialize(unittest.TestCase):
         self.root = tempfile.mkdtemp()
         self.migrator = Migrator(
             "de",
-            os.path.join(self.root, "reference"),
-            os.path.join(self.root, "localization"),
+            join(self.root, "reference"),
+            join(self.root, "localization"),
             False,
         )
 
@@ -44,7 +47,7 @@ class TestSerialize(unittest.TestCase):
         # Walk our serialized localization dir, but
         # make the directory be relative to our root.
         walked = sorted(
-            (os.path.relpath(dir, self.root), sorted(dirs), sorted(files))
+            (relpath(dir, self.root), sorted(dirs), sorted(files))
             for dir, dirs, files in os.walk(self.root)
         )
         self.assertEqual(
@@ -58,18 +61,18 @@ class TestSerialize(unittest.TestCase):
         )
 
 
-class TestCommit(unittest.TestCase):
+class TestHgCommit(unittest.TestCase):
     def setUp(self):
         self.root = tempfile.mkdtemp()
         self.migrator = Migrator(
             "de",
-            os.path.join(self.root, "reference"),
-            os.path.join(self.root, "localization"),
+            join(self.root, "reference"),
+            join(self.root, "localization"),
             False,
         )
-        loc_dir = os.path.join(self.migrator.localization_dir, "d1")
+        loc_dir = join(self.migrator.localization_dir, "d1")
         os.makedirs(loc_dir)
-        with open(os.path.join(loc_dir, "f1"), "w") as f:
+        with open(join(loc_dir, "f1"), "w") as f:
             f.write("first line\n")
         client = hglib.init(self.migrator.localization_dir)
         client.open()
@@ -85,11 +88,57 @@ class TestCommit(unittest.TestCase):
         shutil.rmtree(self.root)
 
     def test_wet(self):
-        """Commit message docstring, part {index}."""
-        with open(os.path.join(self.migrator.localization_dir, "d1", "f1"), "a") as f:
+        """Hg commit message docstring, part {index}."""
+        with open(join(self.migrator.localization_dir, "d1", "f1"), "a") as f:
             f.write("second line\n")
         self.migrator.commit_changeset(self.test_wet.__doc__, "Axel", 2)
-        tip = self.migrator.client.tip()
+        tip = self.migrator.client.hgclient.tip()
         self.assertEqual(tip.rev, b"1")
         self.assertEqual(tip.author, b"Axel")
-        self.assertEqual(tip.desc, b"Commit message docstring, part 2.")
+        self.assertEqual(tip.desc, b"Hg commit message docstring, part 2.")
+
+
+class TestGitCommit(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.migrator = Migrator(
+            "de",
+            join(self.root, "reference"),
+            join(self.root, "localization"),
+            False,
+        )
+
+        loc_dir = join(self.migrator.localization_dir, "d1")
+        os.makedirs(loc_dir)
+        with open(join(loc_dir, "f1"), "w") as f:
+            f.write("first line\n")
+
+        proc = run(
+            ["git", "init"],
+            capture_output=True,
+            cwd=self.migrator.localization_dir,
+            encoding="utf-8",
+        )
+        if proc.returncode != 0:
+            raise Exception(proc.stderr or "git init failed")
+        client = RepoClient(self.migrator.localization_dir)
+        client._git("add", ".")
+        client._git(
+            "commit", "--author=Jane <jane@example.com>", "--message=Initial commit"
+        )
+
+    def tearDown(self):
+        self.migrator.close()
+        shutil.rmtree(self.root)
+
+    def test_wet(self):
+        """Git commit message docstring, part {index}."""
+        with open(join(self.migrator.localization_dir, "d1", "f1"), "a") as f:
+            f.write("second line\n")
+        self.migrator.commit_changeset(
+            self.test_wet.__doc__, "Axel <axel@example.com>", 2
+        )
+        stdout = self.migrator.client._git(
+            "show", "--no-patch", "--pretty=format:%an:%s"
+        )
+        self.assertEqual(stdout, "Axel:Git commit message docstring, part 2.")

--- a/tests/migrate/test_tool.py
+++ b/tests/migrate/test_tool.py
@@ -122,6 +122,8 @@ class TestGitCommit(unittest.TestCase):
         if proc.returncode != 0:
             raise Exception(proc.stderr or "git init failed")
         client = RepoClient(self.migrator.localization_dir)
+        client._git("config", "user.name", "Anon")
+        client._git("config", "user.email", "anon@example.com")
         client._git("add", ".")
         client._git(
             "commit", "--author=Jane <jane@example.com>", "--message=Initial commit"


### PR DESCRIPTION
~This builds on top of #5, so at least currently [these](https://github.com/mozilla/fluent-migrate/pull/6/files/2defc24db8e2e0a4b422b70da710a3de4b4a2eb3..90362e1179761b7c1ca7756bfbc406b12bcd1ff6) are the only proper changes here.~

A new `RepoClient` class is added, with a minimal set of methods as required by the rest of the library for repository operations. A Mercurial repo is detected from the presence of a `.hg` directory, and for Git we look for `.git` and check that `git rev-parse --is-inside-work-tree` returns `true`.

The `hglib` stuff should work just as before; for git we don't need any wrapper library as the command line is plenty. For the blame I did need to write a minimal parser, but that was only about 10 lines of code.

The `Blame().handleFile()` function signature changed a bit through all this, but AFAIK that has no external users.