### PR TITLE
List git log entries from oldest to newest

### DIFF
--- a/fluent/migrate/repo_client.py
+++ b/fluent/migrate/repo_client.py
@@ -99,6 +99,7 @@ class RepoClient:
                 git(
                     self.root,
                     "log",
+                    "--reverse",
                     "--pretty=format:%s",
                     f"{from_commit}..{to_commit}",
                 )


### PR DESCRIPTION
As seen in https://phabricator.services.mozilla.com/D229198#7934480, the `git log` entry order should match that of `hgclient.log()`.